### PR TITLE
Fix multi-line csv parse issue.

### DIFF
--- a/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
+++ b/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
@@ -132,7 +132,7 @@ public final class CSVSerde extends AbstractSerDe {
     Text rowText = (Text) blob;
 
     try {
-      final String[] strings = this.csvParser.parseLine(rowText.toString());
+      final String[] strings = this.csvParser.parseLineMulti(rowText.toString());
 
       for (String thisRow : strings) {
         if (strings != null) {


### PR DESCRIPTION
#2 introduced a bug that resulted in an IO error when attempting to parse multi-line csv files. This fixed that issue.
